### PR TITLE
Fix runtime error related to `wrap`

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -16,7 +16,6 @@ from aqt.utils import askUser
 from aqt.gui_hooks import (
     models_advanced_will_show
 )
-from anki.hooks import wrap
 
 
 def changeLaTeX(latexsvg, header, footer):
@@ -42,8 +41,11 @@ def adjust_dialog(dialog):
                                     f.addWidget(apply_to_all)
 models_advanced_will_show.append(adjust_dialog)
 
+if not hasattr(Models, "_onAdvanced"):
+    Models._onAdvanced = Models.onAdvanced
 
 def onAdvanced(self):
+    Models._onAdvanced(self)
     global apply_to_all
     if apply_to_all.isChecked():
         if askUser("Write these values for the header/footer to ALL notetypes?"):
@@ -51,4 +53,4 @@ def onAdvanced(self):
             changeLaTeX(nt["latexsvg"],
                         nt["latexPre"], 
                         nt["latexPost"])
-Models.onAdvanced = wrap(Models.onAdvanced, onAdvanced)
+Models.onAdvanced = onAdvanced


### PR DESCRIPTION
Thanks for the nice add-on. I tried to use it today, but the error below occured. This is the fix which made it work again :)

This inlines the use of wrap. Therefore we have to keep a reference to the original function, which we save in a new attribute. Even if the code was called multiple times, the `hasattr` check ensures that we don't overwrite the reference with our own function (which would create a cycle)

Before when running the plugin the following exception occured:
```
Caught exception:
Traceback (most recent call last):
  File "decorator", line 231, in fun
  File "decorator", line 203, in fix
  File "inspect", line 3045, in bind
  File "inspect", line 2966, in _bind
TypeError: too many positional arguments
```